### PR TITLE
TEIID-4806  include additional validation check for JDG auth properties

### DIFF
--- a/connector-jdg-hotrod/pom.xml
+++ b/connector-jdg-hotrod/pom.xml
@@ -75,6 +75,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.jboss.teiid.connectors</groupId>
+			<artifactId>translator-jdg-hotrod</artifactId>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>		
+		<dependency>
+			<groupId>org.jboss.teiid.connectors</groupId>
 			<artifactId>translator-object</artifactId>
 			<exclusions>
 				<exclusion>

--- a/connector-jdg-hotrod/src/main/java/org/teiid/resource/adapter/infinispan/hotrod/InfinispanManagedConnectionFactory.java
+++ b/connector-jdg-hotrod/src/main/java/org/teiid/resource/adapter/infinispan/hotrod/InfinispanManagedConnectionFactory.java
@@ -36,10 +36,10 @@ import org.teiid.core.util.ReflectionHelper;
 import org.teiid.core.util.StringUtil;
 import org.teiid.resource.spi.BasicConnectionFactory;
 import org.teiid.resource.spi.BasicManagedConnectionFactory;
-import org.teiid.translator.MetadataProcessor;
 import org.teiid.translator.object.CacheNameProxy;
 import org.teiid.translator.object.ClassRegistry;
-import org.teiid.translator.object.ObjectConnection;
+import org.teiid.logging.LogConstants;
+import org.teiid.logging.LogManager;
 
 
 public class InfinispanManagedConnectionFactory extends BasicManagedConnectionFactory {
@@ -210,26 +210,30 @@ public class InfinispanManagedConnectionFactory extends BasicManagedConnectionFa
 			throw new InvalidPropertyException(InfinispanManagedConnectionFactory.UTIL.getString("TEIID25022") );
 		}
 
-
-		if ((authServerName != null && authSASLMechanism == null)
-				|| (authServerName == null && authSASLMechanism != null)) {
-			throw new InvalidPropertyException("AuthServerName and AuthSASMechanism must be specfied");
-		}
-		
-		if (authSASLMechanism != null) {
-			if (adminUserName == null || adminPassword == null)
-				throw new InvalidPropertyException("AdminUserName and AdminPassword must be specfied");
-			
-			if (authApplicationRealm == null) {
-				throw new InvalidPropertyException("AuthApplicationRealm must be specfied");
-			}		
-	
-			// optional, but both must be specified if they are used
-			if ( (authPassword != null && authUserName == null) || (authPassword == null && authUserName != null)) {
-				throw new InvalidPropertyException("AuthUserName and AuthPassword must be specfied");
-			}
-
-		}
+ 		// if 1 is not-null, then all must be specified
+ 		if (authServerName != null || authSASLMechanism != null || authApplicationRealm != null){
+ 			if (authServerName == null)	
+ 				throw new InvalidPropertyException(InfinispanManagedConnectionFactory.UTIL.getString("TEIID25035") );
+ 			if (authSASLMechanism == null)
+ 				throw new InvalidPropertyException(InfinispanManagedConnectionFactory.UTIL.getString("TEIID25035") );
+ 			if (authApplicationRealm == null)
+ 				throw new InvalidPropertyException(InfinispanManagedConnectionFactory.UTIL.getString("TEIID25035") );
+ 
+ 			if (adminUserName == null || adminPassword == null) {
+ 				throw new InvalidPropertyException(InfinispanManagedConnectionFactory.UTIL.getString("TEIID25036") );
+ 			}	
+ 			
+ 			if ((authUserName != null && authPassword == null) || (authUserName == null && authPassword != null)) {
+ 				throw new InvalidPropertyException(InfinispanManagedConnectionFactory.UTIL.getString("TEIID25036") );
+ 			} 
+ 			
+ 			if (authUserName == null) {
+ 				LogManager.logInfo(LogConstants.CTX_CONNECTOR,
+ 						"=== JDG Resource Adapter - JDG Authentication defaulting to use Subject Credentials ==="); //$NON-NLS-1$
+ 
+ 			}		
+ 		
+ 		}
 		
 		if ( (this.trustStoreFileName != null && this.trustStorePassword == null) ||
 				(this.trustStoreFileName == null && this.trustStorePassword != null) ) {

--- a/connector-jdg-hotrod/src/main/resources/org/teiid/resource/adapter/infinispan/hotrod/i18n.properties
+++ b/connector-jdg-hotrod/src/main/resources/org/teiid/resource/adapter/infinispan/hotrod/i18n.properties
@@ -35,3 +35,5 @@ TEIID25031=MessageMarshaller {0} was incorrectly defined, must have 2 parts: cla
 
 TEIID25033=Truststore filename and password must be specified
 TEIID25034=Keystore filename and password must be specified
+TEIID25035=AuthServerName, AuthSASMechanism AND AuthApplicationRealm must be specfied
+TEIID25036=AdminUserName and AdminPassword must be specfied

--- a/connector-jdg-hotrod/src/test/java/org/teiid/resource/adapter/infinispan/hotrod/TestInfinispanConnectionFactory.java
+++ b/connector-jdg-hotrod/src/test/java/org/teiid/resource/adapter/infinispan/hotrod/TestInfinispanConnectionFactory.java
@@ -21,17 +21,13 @@
  */
 package org.teiid.resource.adapter.infinispan.hotrod;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
 
 import javax.resource.spi.InvalidPropertyException;
 
 import org.jboss.teiid.jdg_remote.pojo.AllTypes;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.teiid.CommandContext;
@@ -261,5 +257,216 @@ public class TestInfinispanConnectionFactory  {
 		afactory.createConnectionFactory().getConnection();
 		
 	}
+	
+		 /**
+	     * TEIID-4608:   validating JDG authorizations properties
+	     * 
+	     * - 
+	     */
+		@Test
+		public void testValidationAuthentication1() throws Exception {
+	
+			afactory.setProtobufDefinitionFile("allTypes.proto");
+			afactory.setMessageMarshallers("org.jboss.teiid.jdg_remote.pojo.AllTypes:org.jboss.teiid.jdg_remote.pojo.marshaller.AllTypesMarshaller");
+			afactory.setMessageDescriptor("org.jboss.teiid.jdg_remote.pojo.AllTypes");
+			afactory.setCacheTypeMap("AllTypesCache:org.jboss.teiid.jdg_remote.pojo.AllTypes");
+			afactory.setHotRodClientPropertiesFile("./src/test/resources/jdg.properties");
+			afactory.setAdminUserName("adminusername");
+			afactory.setAdminPassword("password");
+			afactory.setAuthApplicationRealm("applRealm");
+			afactory.setAuthSASLMechanism("SASL");
+			afactory.setAuthServerName("serverName");
+			afactory.setAuthUserName("username");
+			afactory.setAuthPassword("userpassword");		
+			
+					
+		    afactory.createConnectionFactory().getConnection();
+			
+			assertEquals("adminusername is not the same", "adminusername", afactory.getAdminUserName());
+			assertEquals("admin password is not the same", "password", afactory.getAdminPassword());
+			assertEquals("applRealm is not the same", "applRealm", afactory.getAuthApplicationRealm());
+			assertEquals("SASL is not the same", "SASL", afactory.getAuthSASLMechanism());
+			assertEquals("serverName password is not the same", "serverName", afactory.getAuthServerName());
+			assertEquals("username is not the same", "username", afactory.getAuthUserName());
+			assertEquals("userpassword is not the same", "userpassword", afactory.getAuthPassword());
+		}
+		
+		 /**
+	     * TEIID-4608:   validating JDG authorizations properties
+	     * excludes AuthUsername and Authpassword because they are optional if using Subject credentials
+	     * - 
+	     */
+		@Test
+		public void testValidationAuthentication2() throws Exception {
+	
+			afactory.setProtobufDefinitionFile("allTypes.proto");
+			afactory.setMessageMarshallers("org.jboss.teiid.jdg_remote.pojo.AllTypes:org.jboss.teiid.jdg_remote.pojo.marshaller.AllTypesMarshaller");
+			afactory.setMessageDescriptor("org.jboss.teiid.jdg_remote.pojo.AllTypes");
+			afactory.setCacheTypeMap("AllTypesCache:org.jboss.teiid.jdg_remote.pojo.AllTypes");
+			afactory.setHotRodClientPropertiesFile("./src/test/resources/jdg.properties");
+			afactory.setAdminUserName("adminusername");
+			afactory.setAdminPassword("password");
+			afactory.setAuthApplicationRealm("applRealm");
+			afactory.setAuthSASLMechanism("SASL");
+			afactory.setAuthServerName("serverName");	
+			
+					
+		    afactory.createConnectionFactory().getConnection();
+			
+			assertEquals("adminusername is not the same", "adminusername", afactory.getAdminUserName());
+			assertEquals("admin password is not the same", "password", afactory.getAdminPassword());
+			assertEquals("applRealm is not the same", "applRealm", afactory.getAuthApplicationRealm());
+			assertEquals("SASL is not the same", "SASL", afactory.getAuthSASLMechanism());
+			assertEquals("serverName password is not the same", "serverName", afactory.getAuthServerName());
+			assertNull(afactory.getAuthUserName());
+			assertNull(afactory.getAuthPassword());
+		}
+	
+		
+		 /**
+	     * TEIID-4608:   validating JDG authorizations properties
+	     * 
+	     * This throws expected exception because AdminPassword is not provided
+	     * - 
+	     * @throws Exception
+	     */
+		@Test( expected = javax.resource.spi.InvalidPropertyException.class )
+		public void testValidateAdminPasswordProperty() throws Exception {
+	
+			afactory.setProtobufDefinitionFile("allTypes.proto");
+			afactory.setMessageMarshallers("org.jboss.teiid.jdg_remote.pojo.AllTypes:org.jboss.teiid.jdg_remote.pojo.marshaller.AllTypesMarshaller");
+			afactory.setMessageDescriptor("org.jboss.teiid.jdg_remote.pojo.AllTypes");
+			afactory.setCacheTypeMap("AllTypesCache:org.jboss.teiid.jdg_remote.pojo.AllTypes");
+			afactory.setHotRodClientPropertiesFile("./src/test/resources/jdg.properties");
+			afactory.setAdminUserName("adminusername");
+	//		afactory.setAdminPassword("password");
+			afactory.setAuthApplicationRealm("applRealm");
+			afactory.setAuthSASLMechanism("SASL");
+			afactory.setAuthServerName("serverName");
+			afactory.setAuthUserName("username");
+			afactory.setAuthPassword("userpassword");		
+			
+					
+		    afactory.createConnectionFactory().getConnection();
+			
+		    assertFalse("test should have failed", true);
+		}
+	
+		 /**
+	     * TEIID-4608:   validating JDG authorizations properties
+	     * 
+	     * This throws expected exception because AdminUserName is not provided
+	     * - 
+	     * @throws Exception
+	     */
+		@Test( expected = javax.resource.spi.InvalidPropertyException.class )
+		public void testValidateAdminUsernameProperty() throws Exception {
+	
+			afactory.setProtobufDefinitionFile("allTypes.proto");
+			afactory.setMessageMarshallers("org.jboss.teiid.jdg_remote.pojo.AllTypes:org.jboss.teiid.jdg_remote.pojo.marshaller.AllTypesMarshaller");
+			afactory.setMessageDescriptor("org.jboss.teiid.jdg_remote.pojo.AllTypes");
+			afactory.setCacheTypeMap("AllTypesCache:org.jboss.teiid.jdg_remote.pojo.AllTypes");
+			afactory.setHotRodClientPropertiesFile("./src/test/resources/jdg.properties");
+	//		afactory.setAdminUserName("adminusername");
+			afactory.setAdminPassword("password");
+			afactory.setAuthApplicationRealm("applRealm");
+			afactory.setAuthSASLMechanism("SASL");
+			afactory.setAuthServerName("serverName");
+			afactory.setAuthUserName("username");
+			afactory.setAuthPassword("userpassword");		
+			
+					
+		    afactory.createConnectionFactory().getConnection();
+			
+		    assertFalse("test should have failed", true);
+		}
+		
+		 /**
+	     * TEIID-4608:   validating JDG authorizations properties
+	     * 
+	     * This throws expected exception because AuthUserName is not provided
+	     * - 
+	     * @throws Exception
+	     */
+		@Test( expected = javax.resource.spi.InvalidPropertyException.class )
+		public void testValidateAuthUsernameProperty() throws Exception {
+	
+			afactory.setProtobufDefinitionFile("allTypes.proto");
+			afactory.setMessageMarshallers("org.jboss.teiid.jdg_remote.pojo.AllTypes:org.jboss.teiid.jdg_remote.pojo.marshaller.AllTypesMarshaller");
+			afactory.setMessageDescriptor("org.jboss.teiid.jdg_remote.pojo.AllTypes");
+			afactory.setCacheTypeMap("AllTypesCache:org.jboss.teiid.jdg_remote.pojo.AllTypes");
+			afactory.setHotRodClientPropertiesFile("./src/test/resources/jdg.properties");
+			afactory.setAdminUserName("adminusername");
+			afactory.setAdminPassword("password");
+			afactory.setAuthApplicationRealm("applRealm");
+			afactory.setAuthSASLMechanism("SASL");
+			afactory.setAuthServerName("serverName");
+	//		afactory.setAuthUserName("username");
+			afactory.setAuthPassword("userpassword");		
+			
+					
+		    afactory.createConnectionFactory().getConnection();
+			
+		    assertFalse("test should have failed", true);
+		}
+	
+		 /**
+	     * TEIID-4608:   validating JDG authorizations properties
+	     * 
+	     * This throws expected exception because AuthPassword is not provided
+	     * - 
+	     * @throws Exception
+	     */
+		@Test( expected = javax.resource.spi.InvalidPropertyException.class )
+		public void testValidateAuthPasswordProperty() throws Exception {
+	
+			afactory.setProtobufDefinitionFile("allTypes.proto");
+			afactory.setMessageMarshallers("org.jboss.teiid.jdg_remote.pojo.AllTypes:org.jboss.teiid.jdg_remote.pojo.marshaller.AllTypesMarshaller");
+			afactory.setMessageDescriptor("org.jboss.teiid.jdg_remote.pojo.AllTypes");
+			afactory.setCacheTypeMap("AllTypesCache:org.jboss.teiid.jdg_remote.pojo.AllTypes");
+			afactory.setHotRodClientPropertiesFile("./src/test/resources/jdg.properties");
+			afactory.setAdminUserName("adminusername");
+			afactory.setAdminPassword("password");
+			afactory.setAuthApplicationRealm("applRealm");
+			afactory.setAuthSASLMechanism("SASL");
+			afactory.setAuthServerName("serverName");
+			afactory.setAuthUserName("username");
+	//		afactory.setAuthPassword("userpassword");		
+			
+					
+		    afactory.createConnectionFactory().getConnection();
+			
+		    assertFalse("test should have failed", true);
+		}
+		
+		 /**
+	     * TEIID-4608:   validating JDG authorizations properties
+	     * 
+	     * This throws expected exception because AuthApplicationRealm is not provided
+	     * - 
+	     * @throws Exception
+	     */
+		@Test( expected = javax.resource.spi.InvalidPropertyException.class )
+		public void testValidateApplicationReamProperty() throws Exception {
+	
+			afactory.setProtobufDefinitionFile("allTypes.proto");
+			afactory.setMessageMarshallers("org.jboss.teiid.jdg_remote.pojo.AllTypes:org.jboss.teiid.jdg_remote.pojo.marshaller.AllTypesMarshaller");
+			afactory.setMessageDescriptor("org.jboss.teiid.jdg_remote.pojo.AllTypes");
+			afactory.setCacheTypeMap("AllTypesCache:org.jboss.teiid.jdg_remote.pojo.AllTypes");
+			afactory.setHotRodClientPropertiesFile("./src/test/resources/jdg.properties");
+			afactory.setAdminUserName("adminusername");
+			afactory.setAdminPassword("password");
+	//		afactory.setAuthApplicationRealm("applRealm");
+			afactory.setAuthSASLMechanism("SASL");
+			afactory.setAuthServerName("serverName");
+	//		afactory.setAuthUserName("username");
+	//		afactory.setAuthPassword("userpassword");		
+			
+					
+		    afactory.createConnectionFactory().getConnection();
+			
+		    assertFalse("test should have failed", true);
+		}
+	 
 
 }


### PR DESCRIPTION
TEIID-4806  include additional validation check for JDG auth properties to ensure adminUserName and adminPassword are provided accordingly.