### PR TITLE
TEIID-5058: relaxing the registration of the .proto files when the vd…

### DIFF
--- a/connector-infinispan-hotrod/src/main/java/org/teiid/resource/adapter/infinispan/hotrod/InfinispanManagedConnectionFactory.java
+++ b/connector-infinispan-hotrod/src/main/java/org/teiid/resource/adapter/infinispan/hotrod/InfinispanManagedConnectionFactory.java
@@ -126,21 +126,22 @@ public class InfinispanManagedConnectionFactory extends BasicManagedConnectionFa
 
         public void registerProtobufFile(ProtobufResource protobuf) throws TranslatorException {
             try {
-                if (protobuf != null && !this.registeredProtoFiles.contains(protobuf.getIdentifier())) {
+                if (protobuf != null) {
                     // client side
                     this.ctx.registerProtoFiles(FileDescriptorSource.fromString(protobuf.getIdentifier(), protobuf.getContents()));
 
                     // server side
                     RemoteCache<String, String> metadataCache = this.cacheManager
                             .getCache(ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME);
-                    if (metadataCache != null && metadataCache.get(protobuf.getIdentifier()) == null) {
+                    if (metadataCache != null) {
                         metadataCache.put(protobuf.getIdentifier(), protobuf.getContents());
                         String errors = metadataCache.get(ProtobufMetadataManagerConstants.ERRORS_KEY_SUFFIX);
                         if (errors != null) {
                            throw new TranslatorException(InfinispanManagedConnectionFactory.UTIL.getString("proto_error", errors));
                         }
-                        this.registeredProtoFiles.add(protobuf.getIdentifier());
                     }
+                } else {
+                	throw new TranslatorException(InfinispanManagedConnectionFactory.UTIL.getString("no_protobuf"));
                 }
             } catch(Throwable t) {
                 throw new TranslatorException(t);

--- a/connector-infinispan-hotrod/src/main/resources/org/teiid/resource/adapter/infinispan/hotrod/i18n.properties
+++ b/connector-infinispan-hotrod/src/main/resources/org/teiid/resource/adapter/infinispan/hotrod/i18n.properties
@@ -29,3 +29,4 @@ no_keystore="EXTERNAL" SASL Mechanism enabled, however no Keystore information p
 no_truststore="EXTERNAL" SASL Mechanism enabled, however no Truststore information provided for SSL
 no_truststore_pass=No Truststore password defined
 no_keystore_pass=No Keystore password defined 
+no_protobuf=No protobuf supplied to register


### PR DESCRIPTION
…b is redeployed to overwrite the previous definition