### PR TITLE
TEIID-5144: added check for specific proto-schema name

### DIFF
--- a/connector-infinispan-hotrod/src/main/java/org/teiid/resource/adapter/infinispan/hotrod/InfinispanManagedConnectionFactory.java
+++ b/connector-infinispan-hotrod/src/main/java/org/teiid/resource/adapter/infinispan/hotrod/InfinispanManagedConnectionFactory.java
@@ -21,7 +21,6 @@
  */
 package org.teiid.resource.adapter.infinispan.hotrod;
 
-import java.util.HashSet;
 import java.io.IOException;
 
 import javax.resource.ResourceException;
@@ -212,7 +211,11 @@ public class InfinispanManagedConnectionFactory extends BasicManagedConnectionFa
                     if (metadataCache != null) {
                         metadataCache.put(protobuf.getIdentifier(), protobuf.getContents());
                         String errors = metadataCache.get(ProtobufMetadataManagerConstants.ERRORS_KEY_SUFFIX);
-                        if (errors != null) {
+                        // ispn removes leading '/' in a string in the results
+                        String protoSchemaIdent = (protobuf.getIdentifier().startsWith("/"))
+                                ? protobuf.getIdentifier().substring(1)
+                                : protobuf.getIdentifier();
+                        if (errors != null && isProtoSchemaInErrors(protoSchemaIdent, errors)) {
                            throw new TranslatorException(InfinispanManagedConnectionFactory.UTIL.getString("proto_error", errors));
                         }
                     }
@@ -222,6 +225,15 @@ public class InfinispanManagedConnectionFactory extends BasicManagedConnectionFa
             } catch(Throwable t) {
                 throw new TranslatorException(t);
             }
+        }
+
+        private boolean isProtoSchemaInErrors(String ident, String errors) {
+            for (String s : errors.split("\n")) {
+                if (s.trim().startsWith(ident)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         @Override


### PR DESCRIPTION
".errors" entries are returned as a string, proto-schema names are separated by newline characters.