### PR TITLE
TEIID-5270 Added listeners to JDG cache

### DIFF
--- a/translator-infinispan-hotrod/src/main/java/org/teiid/translator/infinispan/hotrod/InfinispanPlugin.java
+++ b/translator-infinispan-hotrod/src/main/java/org/teiid/translator/infinispan/hotrod/InfinispanPlugin.java
@@ -47,6 +47,7 @@ public class InfinispanPlugin {
 		TEIID25016,
 		TEIID25017,
 		TEIID25018,
-		TEIID25019
+		TEIID25019,
+		TEIID25020
 	}
 }

--- a/translator-infinispan-hotrod/src/main/java/org/teiid/translator/infinispan/hotrod/events/CacheEventListener.java
+++ b/translator-infinispan-hotrod/src/main/java/org/teiid/translator/infinispan/hotrod/events/CacheEventListener.java
@@ -1,0 +1,103 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.translator.infinispan.hotrod.events;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryCreated;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryModified;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryRemoved;
+import org.infinispan.client.hotrod.annotation.ClientListener;
+import org.infinispan.client.hotrod.event.ClientCacheEntryCreatedEvent;
+import org.infinispan.client.hotrod.event.ClientCacheEntryModifiedEvent;
+import org.infinispan.client.hotrod.event.ClientCacheEntryRemovedEvent;
+import org.teiid.logging.LogConstants;
+import org.teiid.logging.LogManager;
+
+/**
+ * @author vhalbert
+ *
+ */
+@ClientListener
+public class CacheEventListener implements CacheEventListenerInterface {
+
+	private float default_load_factor = .75f;
+	private int default_size = 100000;
+	private int cnt = 0;
+	private int pre = 0;
+
+	Set<Object> key = Collections.synchronizedSet(new HashSet<Object>(default_size, default_load_factor));
+
+	@Override
+	public void reset() {
+		key.clear();
+		cnt = 0;
+		pre = 0;
+	}
+	@Override
+	public boolean eventsMonitored() {
+		return true;
+	}
+
+	@Override
+	public int getEventCount() {
+		return key.size();
+	}
+
+	@Override
+	public void addEvent(final Object okey) {
+		key.add(okey);
+	    LogManager.logTrace(LogConstants.CTX_CONNECTOR, ++pre + " [CacheEventListener] Add event (pre) " + okey);
+	}
+
+	@Override
+	public void addEvents(Set<Object> keyset) {
+		key.addAll(keyset);
+	}
+
+	@ClientCacheEntryModified
+	public void handle(ClientCacheEntryModifiedEvent event) {
+		if (pre > 0) {
+			key.remove(event.getKey());
+			LogManager.logTrace(LogConstants.CTX_CONNECTOR, ++cnt + " [CacheEventListener] Modified entry (post) " + event.getKey());
+		}
+	}
+
+	@ClientCacheEntryCreated
+	public void handle(ClientCacheEntryCreatedEvent event) {
+		if (pre > 0) {
+			key.remove(event.getKey());
+			LogManager.logTrace(LogConstants.CTX_CONNECTOR, ++cnt + " [CacheEventListener] Created entry (post) " + event.getKey());
+		}
+	}
+
+	@ClientCacheEntryRemoved
+	public void handle(ClientCacheEntryRemovedEvent event) {
+		if (pre > 0) {
+			key.remove(event.getKey());
+			LogManager.logTrace(LogConstants.CTX_CONNECTOR, ++cnt + " [CacheEventListener] Removed entry (post) " + event.getKey());
+		}
+	}
+
+}

--- a/translator-infinispan-hotrod/src/main/java/org/teiid/translator/infinispan/hotrod/events/CacheEventListenerInterface.java
+++ b/translator-infinispan-hotrod/src/main/java/org/teiid/translator/infinispan/hotrod/events/CacheEventListenerInterface.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.translator.infinispan.hotrod.events;
+
+import java.util.Set;
+
+/**
+ * @author vhalbert
+ *
+ */
+public interface CacheEventListenerInterface {
+
+	/**
+	 * Called to add a single event to the list to be monitored for an event from JDG
+	 * @param okey
+	 */
+	void addEvent(Object okey);
+	
+	/**
+	 * Called to add a set of events to the list to be monitored for an event from JDG
+	 * @param keyset
+	 */
+	void addEvents(Set<Object> keyset);
+	
+	/**
+	 * Called to determine the number of events still in the queue to be listened for
+	 * @return int
+	 */
+	int getEventCount();
+	
+	/**
+	 * Utility method to differentiate between the actual listener and the noop listener.
+	 * @return boolean
+	 */
+	boolean eventsMonitored();
+	
+	/**
+	 * Called to clear out any events that are being monitored and reset counters.
+	 */
+	void reset();
+
+}

--- a/translator-infinispan-hotrod/src/main/java/org/teiid/translator/infinispan/hotrod/events/CacheEventNoOpListener.java
+++ b/translator-infinispan-hotrod/src/main/java/org/teiid/translator/infinispan/hotrod/events/CacheEventNoOpListener.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.translator.infinispan.hotrod.events;
+
+import java.util.Set;
+
+/**
+ * @author vhalbert
+ *
+ */
+public class CacheEventNoOpListener implements CacheEventListenerInterface {
+
+
+	@Override
+	public void reset() {
+	}
+
+	@Override
+	public void addEvent(final Object okey) {
+	}
+
+	@Override
+	public 	void addEvents(Set<Object> keyset) {
+		
+	}
+	
+	@Override
+	public int getEventCount() {
+		return 0;
+	}
+	
+	@Override
+	public boolean eventsMonitored() {
+		return false;
+	}
+	
+	
+
+}

--- a/translator-infinispan-hotrod/src/main/java/org/teiid/translator/infinispan/hotrod/events/EventMonitor.java
+++ b/translator-infinispan-hotrod/src/main/java/org/teiid/translator/infinispan/hotrod/events/EventMonitor.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ */
+package org.teiid.translator.infinispan.hotrod.events;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.teiid.logging.LogConstants;
+import org.teiid.logging.LogManager;
+
+/**
+ * @author vhalbert
+ *
+ */
+final public class EventMonitor {
+	
+	static Map<String, CacheEventListenerInterface> ALIAS_CACHE_EVENTS = new HashMap<String, CacheEventListenerInterface>(); 
+	
+	private static final CacheEventNoOpListener NOOP_LISTENER = new CacheEventNoOpListener();
+
+	/**
+	 * Should be only called by the direct query that triggers the cleaning of the cache before starting materialization
+	 * @param cache
+	 */
+	public static synchronized void addListenerInstance(@SuppressWarnings("rawtypes") RemoteCache cache) {	
+		
+		clearListeners(cache);
+		CacheEventListener m = (CacheEventListener) ALIAS_CACHE_EVENTS.get(cache.getName());
+		if (m == null) {
+			m = new CacheEventListener();
+			ALIAS_CACHE_EVENTS.put(cache.getName(), m);
+		}
+		m.reset();		
+		cache.addClientListener(m);
+
+	}
+	
+	public static synchronized CacheEventListenerInterface getListenerInstance(String cacheName) {
+		
+		if (ALIAS_CACHE_EVENTS.containsKey(cacheName)) {
+			return ALIAS_CACHE_EVENTS.get(cacheName);
+		}
+		
+	    LogManager.logTrace(LogConstants.CTX_CONNECTOR, "[MaterializationEventMonitor] getListenerInstance is returning CacheEventNoOPListener for cache " + cacheName);
+		return NOOP_LISTENER;
+	}
+	
+	private static void clearListeners(@SuppressWarnings("rawtypes") RemoteCache cache) {
+		// clean out any existing listeners
+		Set l = cache.getListeners();
+		if (l != null && ! l.isEmpty()) {
+			for (Object o:l) {
+				cache.removeClientListener(o);
+			}
+		}	
+	}
+}

--- a/translator-infinispan-hotrod/src/main/resources/org/teiid/translator/infinispan/hotrod/i18n.properties
+++ b/translator-infinispan-hotrod/src/main/resources/org/teiid/translator/infinispan/hotrod/i18n.properties
@@ -39,3 +39,4 @@ TEIID25014=Cache store {0} not found
 TEIID25015=Invalid entry in teiid-alias-naming-cache. The key {0} has invalid value {1}
 TEIID25016=Unknown command is being executed using the direct query procedure. {0}
 TEIID25019=With Infinispan, since records are stored using the primary key, updating that column is not supported. So, can not update "{0}" column. You can alternatively delete and re-insert the row.
+TEIID25020=JDG cache issue, the {0} remaining events are not being processed. 


### PR DESCRIPTION
TEIID-5270 Added listeners to JDG cache to enable Teiid to ensure all actions have been processed before renaming staging cache