### PR TITLE
[TEIID-5270] removing trucating the staging table

### DIFF
--- a/translator-infinispan-hotrod/src/main/java/org/teiid/translator/infinispan/hotrod/InfinispanDirectQueryExecution.java
+++ b/translator-infinispan-hotrod/src/main/java/org/teiid/translator/infinispan/hotrod/InfinispanDirectQueryExecution.java
@@ -135,7 +135,6 @@ public class InfinispanDirectQueryExecution implements ProcedureExecution {
     			throw new TranslatorException(InfinispanPlugin.Event.TEIID25015,
     					InfinispanPlugin.Util.gs(InfinispanPlugin.Event.TEIID25015, tableOne, aliasName));
     		}
-    		clearContents(aliasCache, tableOne);
     		return;
     	}
     	


### PR DESCRIPTION
[TEIID-5270] removing trucating the staging table after swapping names so that current queries can complete with the state it started with